### PR TITLE
Remove keyword param from request

### DIFF
--- a/src/yaru/core.clj
+++ b/src/yaru/core.clj
@@ -1,7 +1,6 @@
 (ns yaru.core
   (:require [compojure.core :refer [defroutes routes GET POST PUT DELETE]]
-            [ring.middleware.keyword-params :refer [wrap-keyword-params]]
-            [ring.middleware.json :refer [wrap-json-response wrap-json-params]]
+            [ring.middleware.json :refer [wrap-json-response wrap-json-body]]
             [ring.util.response :refer [response]]
             [yaru.thing :as things])
   (:use ring.adapter.jetty
@@ -13,14 +12,13 @@
    (DELETE "/things/:id" [id] (things/delete id))
    (GET "/things" [] (things/list))
    (GET "/things/:id" [id] (things/get id))
-   (POST "/things" {{thing :thing} :params} (things/post thing))
-   (PUT "/things/:id" {{id :id} :route-params {thing :thing} :params}  (things/put id thing))))
+   (POST "/things" {params :body} (things/post params))
+   (PUT "/things/:id" {{id :id} :params params :body} (things/put id params))))
 
 (def app
   (-> handler
       (wrap-default-charset "utf-8")
-      wrap-keyword-params
-      wrap-json-params
+      (wrap-json-body {:keywords? true})
       wrap-json-response))
 
 (defn -main []

--- a/src/yaru/thing.clj
+++ b/src/yaru/thing.clj
@@ -11,14 +11,14 @@
   (let [things (db.things/all-things db)]
     {:status 200 :body things}))
 
-(defn post [thing]
-  (let [result (db.things/insert-thing-return-keys db thing)
+(defn post [params]
+  (let [result (db.things/insert-thing-return-keys db params)
         id ((keyword "last_insert_rowid()") result)
         thing (db.things/thing-by-id db {:id id})]
     {:status 200 :body thing}))
 
-(defn put [id thing]
-  (let [result (db.things/update-thing-by-id db thing)
+(defn put [id params]
+  (let [result (db.things/update-thing-by-id db params)
         thing (db.things/thing-by-id db {:id id})]
     {:status 200 :body thing}))
 

--- a/test/yaru/thing_test.clj
+++ b/test/yaru/thing_test.clj
@@ -46,7 +46,7 @@
                :color "green"
                :priority "low"}
         response (app (-> (request :post "/things")
-                          (json-body {:thing thing})))
+                          (json-body thing)))
         last-thing (last (things/all-things db))
         json-resp (parse-string (:body response))]
     (is (= 200 (:status response)))
@@ -60,7 +60,7 @@
         thing (things/thing-by-id db {:id id})
         fixed (conj thing {:title "fixed"})
         response (app (-> (request :put (str "/things/" id))
-                          (json-body {:thing fixed})))
+                          (json-body fixed)))
         updated (things/thing-by-id db {:id id})
         parsed (parse-string (:body response))
         expected (parse-string (generate-string updated))]


### PR DESCRIPTION
This may seem like an anti-pattern for most APIs that require the data for to go under a key of the same name in the body of a response.

We're assuming since that name exists in the URI we don't need it twice.

For example:

```
curl -X POST -H "Content-Type: application/json" \
     -d '{"title": "foo", "color": "red", "priority": "high"}' \
     http://localhost:3000/things
```

This would create a new thing with those attributes.

```
curl -X PUT -H "Content-Type: application/json" \
     -d '{"title": "fixed", "color": "yellow", "priority": "medium"}' \
     http://localhost:3000/things/2
```

Would update the existing thing with ID#2 given the provided map.

Without this change, you would have to do something like this:

```
curl -X POST -H "Content-Type: application/json" \
     -d '{"thing":
	   {"title": "bar", "color": "green", "priority": "low"}
	 }' \
     http://localhost:3000/things
```

I'm not sure which I prefer but certainly less typing is involved with this patch, but maybe there is an argument for expecting other stuff in the body?